### PR TITLE
feat: change interruption response from error to message

### DIFF
--- a/examples/client_example.py
+++ b/examples/client_example.py
@@ -22,7 +22,7 @@ import os
 
 from fastmcp import Client
 from langchain.chat_models import init_chat_model
-from langchain_core.messages import HumanMessage, ToolMessage
+from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 from langchain_mcp_adapters.tools import load_mcp_tools
 from langgraph.checkpoint.memory import MemorySaver
@@ -196,18 +196,7 @@ async def run(  # noqa: C901, PLR0915
                     config={"configurable": {"thread_id": "1"}},
                     stream_mode="updates",
                 ):
-                    logger.info(chunk)
                     log_chunk(chunk)
-                    msg = chunk.get("tools", {}).get("messages", [])
-                    msg = msg[-1] if msg else None
-                    if (
-                        isinstance(msg, ToolMessage)
-                        and msg.status == "error"
-                        and "Interrupted by detected speech" in msg.content
-                    ):
-                        break
-                        # wip: seems to work in general but not for multiple
-                        # tool calls in one message
 
         finally:
             logger.info("Leaving meeting")

--- a/examples/client_example.py
+++ b/examples/client_example.py
@@ -22,7 +22,7 @@ import os
 
 from fastmcp import Client
 from langchain.chat_models import init_chat_model
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.tools import tool
 from langchain_mcp_adapters.tools import load_mcp_tools
 from langgraph.checkpoint.memory import MemorySaver
@@ -196,7 +196,18 @@ async def run(  # noqa: C901, PLR0915
                     config={"configurable": {"thread_id": "1"}},
                     stream_mode="updates",
                 ):
+                    logger.info(chunk)
                     log_chunk(chunk)
+                    msg = chunk.get("tools", {}).get("messages", [])
+                    msg = msg[-1] if msg else None
+                    if (
+                        isinstance(msg, ToolMessage)
+                        and msg.status == "error"
+                        and "Interrupted by detected speech" in msg.content
+                    ):
+                        break
+                        # wip: seems to work in general but not for multiple
+                        # tool calls in one message
 
         finally:
             logger.info("Leaving meeting")

--- a/joinly/server.py
+++ b/joinly/server.py
@@ -10,7 +10,7 @@ from pydantic import AnyUrl, Field
 
 from joinly.container import SessionContainer
 from joinly.session import MeetingSession
-from joinly.types import Transcript
+from joinly.types import SpeechInterruptedError, Transcript
 
 if TYPE_CHECKING:
     from mcp import ServerSession
@@ -139,7 +139,10 @@ async def speak_text(
 ) -> str:
     """Speak the given text in the meeting using TTS."""
     ms: MeetingSession = ctx.request_context.lifespan_context.meeting_session
-    await ms.speak_text(text)
+    try:
+        await ms.speak_text(text)
+    except SpeechInterruptedError as e:
+        return str(e)
     return "Finished speaking."
 
 


### PR DESCRIPTION
- Changes the MCP response on a speech interruption from a tool error to a message, this seems to improve the handling of such a response by the LLM since it tries less to correct a mistake