### PR TITLE
fix: deepgram tts leftover audio

### DIFF
--- a/joinly/services/tts/deepgram.py
+++ b/joinly/services/tts/deepgram.py
@@ -95,6 +95,10 @@ class DeepgramTTS(TTS):
             raise RuntimeError(msg)
 
         async with self._lock:
+            # drain the queue to ensure no old data is left
+            while not self._queue.empty():
+                _ = self._queue.get_nowait()
+
             try:
                 await self._client.send_text(text)
                 await self._client.flush()
@@ -103,8 +107,3 @@ class DeepgramTTS(TTS):
                     yield chunk
             finally:
                 await self._client.clear()
-                try:
-                    while True:
-                        self._queue.get_nowait()
-                except asyncio.QueueEmpty:
-                    pass


### PR DESCRIPTION
- fixes a bug, where after an interrupt a portion of the old audio stream was still in the queue on the next stream