### PR TITLE
feat: speech included in transcript

### DIFF
--- a/joinly/controllers/speech/default.py
+++ b/joinly/controllers/speech/default.py
@@ -7,8 +7,16 @@ from typing import Any, Self, cast
 from semchunk.semchunk import chunkerify
 
 from joinly.core import TTS, AudioWriter, SpeechController
-from joinly.types import AudioFormat, SpeechInterruptedError
+from joinly.settings import get_settings
+from joinly.types import (
+    AudioFormat,
+    SpeakerRole,
+    SpeechInterruptedError,
+    Transcript,
+    TranscriptSegment,
+)
 from joinly.utils.audio import calculate_audio_duration, convert_audio_format
+from joinly.utils.clock import Clock
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +60,8 @@ class DefaultSpeechController(SpeechController):
         self._job_queue: asyncio.Queue[SpeakJob] | None = None
         self._worker_task: asyncio.Task | None = None
         self._chunker = chunkerify(lambda s: len(s.split()), chunk_size=15)
+        self._clock: Clock | None = None
+        self._transcript: Transcript | None = None
 
     async def __aenter__(self) -> Self:
         """Enter the audio stream context."""
@@ -61,13 +71,20 @@ class DefaultSpeechController(SpeechController):
         """Stop the audio stream and clean up resources."""
         await self.stop()
 
-    async def start(self) -> None:
-        """Start the speech controller with the given writer and TTS."""
+    async def start(self, clock: Clock, transcript: Transcript) -> None:
+        """Start the speech controller with the given writer and TTS.
+
+        Args:
+            clock (Clock): The clock to use for timing.
+            transcript (Transcript): The transcript to be speech written to.
+        """
         if self._job_queue is not None or self._worker_task is not None:
             msg = "Audio queue already started"
             raise RuntimeError(msg)
 
         self._job_queue = asyncio.Queue(maxsize=self.job_queue_size)
+        self._clock = clock
+        self._transcript = transcript
         self._worker_task = asyncio.create_task(self._worker_loop())
 
     async def stop(self) -> None:
@@ -85,6 +102,9 @@ class DefaultSpeechController(SpeechController):
                 job.done.set()
                 self._job_queue.task_done()
             self._job_queue = None
+
+        self._clock = None
+        self._transcript = None
 
     async def speak_text(
         self,
@@ -106,7 +126,7 @@ class DefaultSpeechController(SpeechController):
             QueueFull: If the queue is full.
         """
         if self._job_queue is None:
-            msg = "Audio queue not initialized"
+            msg = "Speech controller not active"
             raise RuntimeError(msg)
 
         logger.info("Enqueuing text: %s", text)
@@ -123,14 +143,14 @@ class DefaultSpeechController(SpeechController):
     async def wait_until_no_speech(self) -> None:
         """Wait until all speech jobs in the queue are done."""
         if self._job_queue is None:
-            msg = "Audio queue not initialized"
+            msg = "Speech controller not active"
             raise RuntimeError(msg)
         await self._job_queue.join()
 
     async def _worker_loop(self) -> None:
         """Run the worker loop to process audio chunks."""
         if self._job_queue is None:
-            msg = "Audio queue not initialized"
+            msg = "Speech controller not active"
             raise RuntimeError(msg)
 
         while True:
@@ -189,7 +209,7 @@ class DefaultSpeechController(SpeechController):
         words = text.split(" ")
         return " ".join(words[: min(word_num, len(words))])
 
-    async def _speak_text(  # noqa: C901
+    async def _speak_text(  # noqa: C901, PLR0912, PLR0915
         self, text: str, *, interrupt: bool, interruptable: bool
     ) -> None:
         """Speak the given text using the virtual microphone.
@@ -202,6 +222,10 @@ class DefaultSpeechController(SpeechController):
         Raises:
             RuntimeError: If the speech was interrupted.
         """
+        if self._transcript is None or self._clock is None:
+            msg = "Speech controller not active"
+            raise RuntimeError(msg)
+
         chunks = await self._chunk_text(text)
         logger.info("Speaking text (chunks): %s", chunks)
 
@@ -252,6 +276,7 @@ class DefaultSpeechController(SpeechController):
                 if not interrupt and chunk_idx == 0:
                     await self.no_speech_event.wait()
 
+                start = self._clock.now_s
                 while len(buffer) >= self.writer.chunk_size:
                     # check for speech interruption
                     if (
@@ -262,16 +287,22 @@ class DefaultSpeechController(SpeechController):
                         )
                         > self.non_interruptable
                     ):
-                        spoken_text = " ".join(
-                            [
-                                *chunks[:chunk_idx],
-                                await self._estimate_spoken_text(
-                                    chunks[chunk_idx],
-                                    chunk_byte_size,
-                                    self.writer.audio_format,
-                                ),
-                            ]
+                        estimated_text = await self._estimate_spoken_text(
+                            chunks[chunk_idx],
+                            chunk_byte_size,
+                            self.writer.audio_format,
                         )
+                        self._transcript.add_segment(
+                            TranscriptSegment(
+                                text=estimated_text + "...",
+                                start=start,
+                                end=self._clock.now_s,
+                                speaker=get_settings().name,
+                                role=SpeakerRole.assistant,
+                            )
+                        )
+
+                        spoken_text = " ".join([*chunks[:chunk_idx], estimated_text])
                         msg = (
                             f"Interrupted by detected speech. Spoken until now: "
                             f'"{spoken_text}"'
@@ -282,6 +313,16 @@ class DefaultSpeechController(SpeechController):
                     byte_size += self.writer.chunk_size
                     chunk_byte_size += self.writer.chunk_size
                     del buffer[: self.writer.chunk_size]
+
+                self._transcript.add_segment(
+                    TranscriptSegment(
+                        text=chunks[chunk_idx],
+                        start=start,
+                        end=self._clock.now_s,
+                        speaker=get_settings().name,
+                        role=SpeakerRole.assistant,
+                    )
+                )
 
         except SpeechInterruptedError as e:
             logger.info("%s", e)

--- a/joinly/core.py
+++ b/joinly/core.py
@@ -268,8 +268,13 @@ class SpeechController(Protocol):
     tts: TTS
     no_speech_event: asyncio.Event
 
-    async def start(self) -> None:
-        """Start the speech output process."""
+    async def start(self, clock: Clock, transcript: Transcript) -> None:
+        """Start the speech output process.
+
+        Args:
+            clock: The clock to use for timing.
+            transcript: The transcript object to which the speech will be added.
+        """
         ...
 
     async def stop(self) -> None:

--- a/joinly/server.py
+++ b/joinly/server.py
@@ -10,7 +10,12 @@ from pydantic import AnyUrl, Field
 
 from joinly.container import SessionContainer
 from joinly.session import MeetingSession
-from joinly.types import MeetingChatHistory, SpeechInterruptedError, Transcript
+from joinly.types import (
+    MeetingChatHistory,
+    SpeakerRole,
+    SpeechInterruptedError,
+    Transcript,
+)
 
 if TYPE_CHECKING:
     from mcp import ServerSession
@@ -86,7 +91,7 @@ mcp = FastMCP(
 async def get_transcript(ctx: Context) -> Transcript:
     """Get the live transcript of the meeting."""
     ms: MeetingSession = ctx.request_context.lifespan_context.meeting_session
-    return ms.transcript
+    return ms.transcript.with_role(SpeakerRole.participant)
 
 
 @mcp.tool(

--- a/joinly/session.py
+++ b/joinly/session.py
@@ -85,7 +85,7 @@ class MeetingSession:
         self._transcript = Transcript()
         await self._meeting_provider.join(meeting_url, participant_name, passcode)
         await self._transcription_controller.start(self._clock, self._transcript)
-        await self._speech_controller.start()
+        await self._speech_controller.start(self._clock, self._transcript)
 
     async def leave_meeting(self, *, force: bool = False) -> None:
         """Leave the current meeting.

--- a/joinly/types.py
+++ b/joinly/types.py
@@ -157,13 +157,18 @@ class Transcript(BaseModel):
         }
 
     def after(self, seconds: float) -> "Transcript":
-        """Return a transcript containing the segments after the given seconds."""
+        """Return a transcript copy containing the segments after the given seconds."""
         filtered = [s for s in self.segments if s.start > seconds]
         return Transcript(segments=filtered)
 
     def before(self, seconds: float) -> "Transcript":
-        """Return a transcript containing the segments before the given seconds."""
+        """Return a transcript copy containing the segments before the given seconds."""
         filtered = [s for s in self.segments if s.end < seconds]
+        return Transcript(segments=filtered)
+
+    def with_role(self, role: SpeakerRole) -> "Transcript":
+        """Return a transcript copy containing segments with the specified role."""
+        filtered = [s for s in self.segments if s.role == role]
         return Transcript(segments=filtered)
 
 

--- a/joinly/types.py
+++ b/joinly/types.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, computed_field
 
@@ -58,6 +59,18 @@ class SpeechWindow:
     is_speech: bool
 
 
+class SpeakerRole(str, Enum):
+    """An enumeration of speaker roles in a meeting.
+
+    Attributes:
+        participant (str): Represents a (normal) participant in the meeting.
+        assistant (str): Represents this assistant in the meeting.
+    """
+
+    participant = "participant"
+    assistant = "assistant"
+
+
 class TranscriptSegment(BaseModel):
     """A class to represent a segment of a transcript.
 
@@ -72,6 +85,7 @@ class TranscriptSegment(BaseModel):
     start: float
     end: float
     speaker: str | None = None
+    role: SpeakerRole = Field(default=SpeakerRole.participant, exclude=True)
 
     model_config = ConfigDict(frozen=True)
 


### PR DESCRIPTION
- adds text emitted through `speak_text` to the meeting transcript
- this is available in the `get_transcript` tool, but the transcript resource will continue to only include speech from normal participants