### PR TITLE
fix: fail on failed deepgram connection

### DIFF
--- a/joinly/services/stt/deepgram.py
+++ b/joinly/services/stt/deepgram.py
@@ -108,6 +108,10 @@ class DeepgramSTT(STT):
             self._live_options.model,
         )
         await self._client.start(self._live_options)
+        if not await self._client.is_connected():
+            msg = "Failed to connect to Deepgram STT service."
+            logger.error(msg)
+            raise RuntimeError(msg)
         logger.info("Connected to Deepgram STT service")
 
         return self

--- a/joinly/services/tts/deepgram.py
+++ b/joinly/services/tts/deepgram.py
@@ -71,6 +71,10 @@ class DeepgramTTS(TTS):
             self._speak_options.model,
         )
         await self._client.start(self._speak_options)
+        if not await self._client.is_connected():
+            msg = "Failed to connect to Deepgram TTS service."
+            logger.error(msg)
+            raise RuntimeError(msg)
         logger.info("Connected to Deepgram TTS service")
 
         return self


### PR DESCRIPTION
- add a connection check to early fail on a failed connection to the deepgram API