### PR TITLE
fix: no new segment after interrupt

### DIFF
--- a/joinly/server.py
+++ b/joinly/server.py
@@ -92,7 +92,7 @@ mcp = FastMCP(
 async def get_transcript(ctx: Context) -> Transcript:
     """Get the live transcript of the meeting."""
     ms: MeetingSession = ctx.request_context.lifespan_context.meeting_session
-    return ms.transcript.with_role(SpeakerRole.participant).compact()
+    return ms.transcript.with_role(SpeakerRole.participant)
 
 
 @mcp.tool(


### PR DESCRIPTION
- fixes a bug, where sometimes no new segment is detected in the client after a direct interrupt
- removes `.compact()` of the transcript for `transcript://live` resource, which caused merged segments to be missed